### PR TITLE
Filter out worktrees when parsing branches

### DIFF
--- a/main.go
+++ b/main.go
@@ -25,7 +25,7 @@ func parseBranches(gitOutput string) []string {
 		}
 
 		// Skip worktree branches (lines starting with +)
-		if strings.HasPrefix(line, "+") {
+		if strings.HasPrefix(line, "+ ") {
 			continue
 		}
 

--- a/main.go
+++ b/main.go
@@ -13,16 +13,32 @@ import (
 var version = "dev"
 
 // parseBranches extracts branch names from git branch output,
-// filtering out the current branch marker (*) and protected branches (main, master)
+// filtering out the current branch marker (*), protected branches (main, master),
+// and worktrees (prefixed with +)
 func parseBranches(gitOutput string) []string {
 	scanner := bufio.NewScanner(strings.NewReader(gitOutput))
-	scanner.Split(bufio.ScanWords)
 	var branches []string
 	for scanner.Scan() {
-		text := scanner.Text()
-		if text != "*" && text != "main" && text != "master" {
-			branches = append(branches, text)
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
 		}
+
+		// Skip worktree branches (lines starting with +)
+		if strings.HasPrefix(line, "+") {
+			continue
+		}
+
+		// Remove current branch marker (*)
+		line = strings.TrimPrefix(line, "* ")
+		line = strings.TrimSpace(line)
+
+		// Skip protected branches
+		if line == "main" || line == "master" {
+			continue
+		}
+
+		branches = append(branches, line)
 	}
 	return branches
 }

--- a/main_test.go
+++ b/main_test.go
@@ -52,6 +52,26 @@ func TestParseBranches(t *testing.T) {
   release-1.0.0`,
 			expected: []string{"feature/new-ui", "bugfix/JIRA-123", "release-1.0.0"},
 		},
+		{
+			name: "output with worktree branches",
+			input: `* main
+  test
+  test1
+  test2
++ worktree-test1
++ worktree-test2`,
+			expected: []string{"test", "test1", "test2"},
+		},
+		{
+			name: "mixed worktrees and regular branches",
+			input: `  develop
+* main
++ worktree-feature
+  feature-1
++ worktree-hotfix
+  feature-2`,
+			expected: []string{"develop", "feature-1", "feature-2"},
+		},
 	}
 
 	for _, tt := range tests {

--- a/main_test.go
+++ b/main_test.go
@@ -68,9 +68,10 @@ func TestParseBranches(t *testing.T) {
 * main
 + worktree-feature
   feature-1
+  +branch-with-+-prefix
 + worktree-hotfix
   feature-2`,
-			expected: []string{"develop", "feature-1", "feature-2"},
+			expected: []string{"develop", "feature-1", "+branch-with-+-prefix", "feature-2"},
 		},
 	}
 

--- a/main_test.go
+++ b/main_test.go
@@ -3,13 +3,15 @@ package main
 import (
 	"reflect"
 	"testing"
+
+	"github.com/Haugen/bcu/renderer"
 )
 
 func TestParseBranches(t *testing.T) {
 	tests := []struct {
 		name     string
 		input    string
-		expected []string
+		expected []renderer.Branch
 	}{
 		{
 			name: "typical git branch output with current branch",
@@ -17,14 +19,21 @@ func TestParseBranches(t *testing.T) {
   feature-1
   feature-2
   bugfix-123`,
-			expected: []string{"feature-1", "feature-2", "bugfix-123"},
+			expected: []renderer.Branch{
+				{Name: "feature-1", IsActive: false},
+				{Name: "feature-2", IsActive: false},
+				{Name: "bugfix-123", IsActive: false},
+			},
 		},
 		{
 			name: "output with master branch",
 			input: `  develop
 * master
   hotfix-456`,
-			expected: []string{"develop", "hotfix-456"},
+			expected: []renderer.Branch{
+				{Name: "develop", IsActive: false},
+				{Name: "hotfix-456", IsActive: false},
+			},
 		},
 		{
 			name: "output with both main and master",
@@ -32,17 +41,20 @@ func TestParseBranches(t *testing.T) {
   master
   feature-a
   feature-b`,
-			expected: []string{"feature-a", "feature-b"},
+			expected: []renderer.Branch{
+				{Name: "feature-a", IsActive: false},
+				{Name: "feature-b", IsActive: false},
+			},
 		},
 		{
 			name:     "only main branch exists",
 			input:    "* main",
-			expected: []string{},
+			expected: []renderer.Branch{},
 		},
 		{
 			name:     "empty output",
 			input:    "",
-			expected: []string{},
+			expected: []renderer.Branch{},
 		},
 		{
 			name: "branches with special characters",
@@ -50,7 +62,11 @@ func TestParseBranches(t *testing.T) {
   feature/new-ui
   bugfix/JIRA-123
   release-1.0.0`,
-			expected: []string{"feature/new-ui", "bugfix/JIRA-123", "release-1.0.0"},
+			expected: []renderer.Branch{
+				{Name: "feature/new-ui", IsActive: false},
+				{Name: "bugfix/JIRA-123", IsActive: false},
+				{Name: "release-1.0.0", IsActive: false},
+			},
 		},
 		{
 			name: "output with worktree branches",
@@ -60,7 +76,13 @@ func TestParseBranches(t *testing.T) {
   test2
 + worktree-test1
 + worktree-test2`,
-			expected: []string{"test", "test1", "test2"},
+			expected: []renderer.Branch{
+				{Name: "test", IsActive: false},
+				{Name: "test1", IsActive: false},
+				{Name: "test2", IsActive: false},
+				{Name: "worktree-test1", IsActive: true},
+				{Name: "worktree-test2", IsActive: true},
+			},
 		},
 		{
 			name: "mixed worktrees and regular branches",
@@ -68,10 +90,15 @@ func TestParseBranches(t *testing.T) {
 * main
 + worktree-feature
   feature-1
-  +branch-with-+-prefix
 + worktree-hotfix
   feature-2`,
-			expected: []string{"develop", "feature-1", "+branch-with-+-prefix", "feature-2"},
+			expected: []renderer.Branch{
+				{Name: "develop", IsActive: false},
+				{Name: "worktree-feature", IsActive: true},
+				{Name: "feature-1", IsActive: false},
+				{Name: "worktree-hotfix", IsActive: true},
+				{Name: "feature-2", IsActive: false},
+			},
 		},
 	}
 


### PR DESCRIPTION
Addressing issue around worktrees ending up in the output from bcu. Changing `parseBranches` to read lines instead of words, and then filtering out any line starting with `+` followed by a space. This should ignore any worktree and just return good old branches.

This PR closes #1.