### PR TITLE
fix: clear terminal UI on exit using alternate screen buffer

### DIFF
--- a/renderer/renderer.go
+++ b/renderer/renderer.go
@@ -123,6 +123,12 @@ func (r *Renderer) countActualLines(lines []string) int {
 }
 
 func (r *Renderer) Run() []string {
+
+	// Switch to alternate screen buffer
+	fmt.Print("\033[?1049h")
+	defer fmt.Print("\033[?1049l") // Switch back on exit
+
+
 	oldState, err := term.MakeRaw(int(os.Stdin.Fd()))
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
Previously, the branch selector UI remained visible in the terminal after exiting, cluttering the screen. This fix switches to using the alternate screen buffer (like vim/less), which automatically cleans up the UI when the program exits.

- Add alternate screen buffer switching (\033[?1049h / \033[?1049l)
- UI now completely disappears on exit, restoring terminal to original state
- Provides cleaner user experience without leaving artifacts

Fixes the issue where checkbox list remained visible after program exit.